### PR TITLE
Bugfix: not correctly naming the configurations in the scan

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 =======
 History
 =======
+2025.8.5 -- Bugfix: not correclty naming the configurations in the scan
+   * The code did not correctly name the configurations generated during a scan, so
+     their names were None.
+
 2025.5.7 -- Enhancement to continue if minimization does not converge
    * Continue even if the minimization does not fully converge, as sometimes seems to be
      the case.

--- a/energy_scan_step/energy_scan.py
+++ b/energy_scan_step/energy_scan.py
@@ -845,11 +845,10 @@ class EnergyScan(seamm.Node):
             _, self._working_configuration = self.get_system_configuration(
                 P={
                     "structure handling": "Create a new configuration",
-                    "configuration name": label,
-                    "system name": "keep current name",
                 },
             )
             system.configuration = self.working_configuration
+            self._working_configuration.name = label
 
             # Set the coordinates to the updated ones for this scan
             self.working_configuration.coordinates_from_RDKMol(rdkMol)


### PR DESCRIPTION
* The code did not correctly name the configurations generated during a scan, so their names were None.